### PR TITLE
Fix up the correct dependencies.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -15,8 +15,12 @@
     {lager, ".*", {git, "git://github.com/basho/lager.git",
                   {branch, "master"}}},
 
+    %% ranch TCP connection manager
+    {ranch, ".*", {git, "git://github.com/extend/ranch.git",
+            {tag, "0.6.1"}}},
+    
     %% cowboy HTTP handler
     {cowboy, ".*", {git, "git://github.com/refuge/cowboy.git",
-            {branch, "master"}}}
+            {tag, "0.4.0"}}}
 ]}.
 


### PR DESCRIPTION
upnp uses two things we did not know about in rebar.config

One it uses ranch. Two, we need to fix the version of cowboy to an old version for
now until we can bump it.

The problem is due to cowboy being old as well. This requires some coordinated planning.
